### PR TITLE
fix: Set correct peerDependency on gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "eslint": "^7.4.0",
     "prettier": "^2.0.5",
     "rimraf": "3.x"
+  },
+  "peerDependencies": {
+    "gatsby": "^3.0.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
Hello @chadly, Gatsby maintainer here 👋 
First and foremost, thanks for creating the plugin & maintaining it. Much appreciated!

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is not set. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

Thanks!
